### PR TITLE
handle interrupt signal

### DIFF
--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -336,7 +336,7 @@ func (p *pipelineImpl) Init() error {
 	go func() {
 		for sig := range signals {
 			if sig == os.Interrupt {
-				p.logger.Infof("Received interrupt signal, stopping pipeline")
+				p.logger.Infof("Pipeline received interrupt signal, stopping pipeline. p.pipelineMetadata.NextRound: %d", p.pipelineMetadata.NextRound)
 				p.Stop()
 			}
 		}

--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -334,10 +334,9 @@ func (p *pipelineImpl) Init() error {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
-		for sig := range stop {
-			p.logger.Infof("Pipeline received stopping signal <%v>, stopping pipeline. p.pipelineMetadata.NextRound: %d", sig, p.pipelineMetadata.NextRound)
-			p.Stop()
-		}
+		sig := <-stop
+		p.logger.Infof("Pipeline received stopping signal <%v>, stopping pipeline. p.pipelineMetadata.NextRound: %d", sig, p.pipelineMetadata.NextRound)
+		p.Stop()
 	}()
 
 	return err

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter.go
@@ -148,7 +148,7 @@ func (exp *postgresqlExporter) Close() error {
 
 	exp.cf()
 	exp.wg.Wait()
-	exp.logger.Infof("exporter postgresql.Close() at round %d", exp.round)
+	exp.logger.Infof("exporter postgresql.Close() at round %d", atomic.LoadUint64(&exp.round))
 	return nil
 }
 

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter.go
@@ -148,6 +148,7 @@ func (exp *postgresqlExporter) Close() error {
 
 	exp.cf()
 	exp.wg.Wait()
+	exp.logger.Infof("exporter postgresql.Close() at round %d", exp.round)
 	return nil
 }
 
@@ -167,6 +168,7 @@ func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
 		return err
 	}
 	atomic.StoreUint64(&exp.round, exportData.Round()+1)
+
 	return nil
 }
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -441,7 +441,7 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 		dt := time.Since(start)
 		getAlgodRawBlockTimeSeconds.Observe(dt.Seconds())
 		if err != nil {
-			algodImp.logger.Errorf("error getting block for round %d (attempt %d): %s", rnd, r, err.Error())
+			algodImp.logger.Infof("importer algod.Close() at round %d", atomic.LoadUint64(&algodImp.round))
 			continue
 		}
 		tmpBlk := new(models.BlockResponse)

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -441,7 +441,7 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 		dt := time.Since(start)
 		getAlgodRawBlockTimeSeconds.Observe(dt.Seconds())
 		if err != nil {
-			algodImp.logger.Infof("importer algod.Close() at round %d", atomic.LoadUint64(&algodImp.round))
+			algodImp.logger.Infof("error getting block for round %d (attempt %d)", rnd, r)
 			continue
 		}
 		tmpBlk := new(models.BlockResponse)


### PR DESCRIPTION
## Summary

Gracefully handling interrupt signal. The non-gracefulness was discovered during block-generator testing.  The following new printouts are being generated (which without the new go-routine are _NOT_ printed).

```sh
{"__type":"Conduit","_name":"main","level":"info","msg":"Pipeline received interrupt signal, stopping pipeline. p.pipelineMetadata.NextRound: 14","time":"2023-06-09T14:47:06-05:00"}
{"__type":"importer","_name":"algod","level":"trace","msg":"importer algod.GetBlock() called BlockRaw(14) err: context canceled","time":"2023-06-09T14:47:06-05:00"}
{"__type":"importer","_name":"algod","level":"error","msg":"error getting block for round 14 (attempt 0): context canceled","time":"2023-06-09T14:47:06-05:00"}
{"__type":"importer","_name":"algod","level":"trace","msg":"importer algod.GetBlock() called StatusAfterBlock(13) err: context canceled","time":"2023-06-09T14:47:06-05:00"}
{"__type":"Conduit","_name":"main","level":"error","msg":"GetBlock ctx error: context canceled","time":"2023-06-09T14:47:06-05:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Retry number 1 resuming after a 1s retry delay.","time":"2023-06-09T14:47:06-05:00"}
{"__type":"importer","_name":"algod","level":"info","msg":"importer algod.Close() at round 14","time":"2023-06-09T14:47:07-05:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Pipeline.Stop(): Importer (algod) closed without error","time":"2023-06-09T14:47:07-05:00"}
{"__type":"importer","_name":"algod","level":"info","msg":"importer algod.Close() at round 14","time":"2023-06-09T14:47:07-05:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Pipeline.Stop(): Importer (algod) closed without error","time":"2023-06-09T14:47:07-05:00"}
{"__type":"exporter","_name":"postgresql","level":"info","msg":"exporter postgresql.Close() at round 14","time":"2023-06-09T14:47:07-05:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Pipeline.Stop(): Exporter (postgresql) closed without error","time":"2023-06-09T14:47:07-05:00"}
{"__type":"exporter","_name":"postgresql","level":"info","msg":"exporter postgresql.Close() at round 14","time":"2023-06-09T14:47:07-05:00"}
```
I'm not sure why the `closed without error` lines are getting repeated for each plugin.


## Test Plan
WOMM